### PR TITLE
ci: backport commits from main

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,27 +5,33 @@ on: [pull_request]
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the changed files back to the repository.
+      contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
+        with:
+          show-progress: false
+
       - name: Lint
         uses: psf/black@stable
         with:
             options: "-t py312"
+
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5.0.0
         with:
-          python-version: 3.12  # ajusta esto según tus necesidades
+          python-version: 3.12
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install autoflake
+
       - name: Remove unused variables
         run: autoflake --recursive --in-place --exclude=settings.py  --remove-all-unused-imports --remove-duplicate-keys --remove-unused-variables .
-      - name: Git config
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
+
       - name: Push formatted code
         uses: stefanzweifel/git-auto-commit-action@v5
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           show-progress: false
+          fetch-depth: 0
 
       - name: Lint
         uses: psf/black@stable
@@ -32,7 +33,14 @@ jobs:
       - name: Remove unused variables
         run: autoflake --recursive --in-place --exclude=settings.py  --remove-all-unused-imports --remove-duplicate-keys --remove-unused-variables .
 
+      # In case other workflows pushed changes before this one
+      - name: Pull new changes
+        run: |
+          git config pull.rebase true
+          git config rebase.autoStash true
+          git pull
+
       - name: Push formatted code
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v5.0.0
         with:
           commit_message: "style: lint code"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,10 @@
 name: Lint
 
-on: [pull_request]
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
 
 jobs:
   lint:

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -8,7 +8,10 @@ on:
   push:
     branches:
       - develop
+      - main
   pull_request:
+    branches:
+      - develop
 
 jobs:
   generate:

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - main
-      - develop
   pull_request:
     branches:
       - main
@@ -46,7 +45,7 @@ jobs:
 
       - name: Check if the schema was modified
         id: diff
-        run: echo "count=$(git status -su | grep openapi.yaml | wc -l)" >> $GITHUB_OUTPUT
+        run: echo "::set-output name=count::$(git status -su | grep openapi.yaml | wc -l)"
 
       # "echo" in commit returns true so the build succeeds, even if no changed files
       - name: Commit new changes to the repo
@@ -54,8 +53,6 @@ jobs:
         run: |
           git config user.name GitHub Actions
           git config user.email action@github.com
-          git config pull.rebase true
-          git config rebase.autoStash true
           git pull
           git add .
           git commit -m "ci: update OpenAPI schema" || echo

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+      - develop
   pull_request:
     branches:
       - main
@@ -45,7 +46,7 @@ jobs:
 
       - name: Check if the schema was modified
         id: diff
-        run: echo "::set-output name=count::$(git status -su | grep openapi.yaml | wc -l)"
+        run: echo "count=$(git status -su | grep openapi.yaml | wc -l)" >> $GITHUB_OUTPUT
 
       # "echo" in commit returns true so the build succeeds, even if no changed files
       - name: Commit new changes to the repo
@@ -53,6 +54,8 @@ jobs:
         run: |
           git config user.name GitHub Actions
           git config user.email action@github.com
+          git config pull.rebase true
+          git config rebase.autoStash true
           git pull
           git add .
           git commit -m "ci: update OpenAPI schema" || echo

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - develop
-      - main
   pull_request:
     branches:
       - develop
@@ -78,4 +77,5 @@ jobs:
           repo: axios-apiclient
           github_token: ${{ secrets.GH_TOKEN }}
           workflow_file_name: generation.yml
+          ref: ${{ github.ref_name }}
           wait_workflow: false

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -7,12 +7,11 @@ concurrency:
 on:
   push:
     branches:
-      - main
       - develop
   pull_request:
     branches:
-      - main
       - develop
+
 jobs:
   generate:
     runs-on: ubuntu-latest
@@ -24,6 +23,9 @@ jobs:
       DB_PASSWORD: ocialpass123
       DB_HOST: localhost
       DB_PORT: 5432
+    
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout ⬇️
@@ -45,18 +47,20 @@ jobs:
         run: python ./manage.py spectacular --file openapi.yaml --validate --fail-on-warn
 
       - name: Check if the schema was modified
+        if: ${{ github.event_name == 'push' }}
         id: diff
         run: echo "count=$(git status -su | grep openapi.yaml | wc -l)" >> $GITHUB_OUTPUT
 
-      # "echo" in commit returns true so the build succeeds, even if no changed files
-      - name: Commit new changes to the repo
-        if: ${{ steps.diff.outputs.count > 0 && github.event_name != 'pull_request' }}
+      # In case other workflows pushed changes before this one
+      - name: Pull new changes
+        if: ${{ steps.diff.outputs.count > 0 && github.event_name == 'push' }}
         run: |
-          git config user.name GitHub Actions
-          git config user.email action@github.com
           git config pull.rebase true
           git config rebase.autoStash true
           git pull
-          git add .
-          git commit -m "ci: update OpenAPI schema" || echo
-          git push
+
+      - name: Push formatted code
+        if: ${{ steps.diff.outputs.count > 0 && github.event_name == 'push' }}
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "ci: update openapi.yaml"

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -9,12 +9,11 @@ on:
     branches:
       - develop
   pull_request:
-    branches:
-      - develop
 
 jobs:
   generate:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
     env:
       DEBUG: True
       KEY: ${{ secrets.SECRET_KEY }}
@@ -47,26 +46,29 @@ jobs:
         run: python ./manage.py spectacular --file openapi.yaml --validate --fail-on-warn
 
       - name: Check if the schema was modified
-        if: ${{ github.event_name == 'push' }}
         id: diff
         run: echo "count=$(git status -su | grep openapi.yaml | wc -l)" >> $GITHUB_OUTPUT
 
       # In case other workflows pushed changes before this one
       - name: Pull new changes
-        if: ${{ steps.diff.outputs.count > 0 && github.event_name == 'push' }}
+        if: ${{ steps.diff.outputs.count > 0 }}
         run: |
           git config pull.rebase true
           git config rebase.autoStash true
           git pull
 
       - name: Push formatted code
-        if: ${{ steps.diff.outputs.count > 0 && github.event_name == 'push' }}
-        uses: stefanzweifel/git-auto-commit-action@v5
+        if: ${{ steps.diff.outputs.count > 0 }}
+        uses: stefanzweifel/git-auto-commit-action@v5.0.0
         with:
           commit_message: "ci: update openapi.yaml"
 
+  dispatch:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' }}
+
+    steps:
       - name: Trigger generation workflow in axios-apiclient
-        if: ${{ steps.diff.outputs.count > 0 && github.event_name == 'push' }}
         uses: convictional/trigger-workflow-and-wait@v1.6.5
         with:
           owner: ispp-2324-ocial

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -64,3 +64,13 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "ci: update openapi.yaml"
+
+      - name: Trigger generation workflow in axios-apiclient
+        if: ${{ steps.diff.outputs.count > 0 && github.event_name == 'push' }}
+        uses: convictional/trigger-workflow-and-wait@v1.6.5
+        with:
+          owner: ispp-2324-ocial
+          repo: axios-apiclient
+          github_token: ${{ secrets.GH_TOKEN }}
+          workflow_file_name: generation.yml
+          wait_workflow: false

--- a/.github/workflows/quality_checks.yml
+++ b/.github/workflows/quality_checks.yml
@@ -6,6 +6,9 @@ concurrency:
 
 on:
   pull_request:
+    branches:
+      - main
+      - develop
   merge_group:
 
 env:

--- a/.github/workflows/quality_checks.yml
+++ b/.github/workflows/quality_checks.yml
@@ -8,6 +8,14 @@ on:
   pull_request:
   merge_group:
 
+env:
+  DB_IMAGE: postgres:latest
+  DB_NAME: ocialdb
+  DB_USERNAME: ocialuser
+  DB_PASSWORD: ocialpass123
+  # Necesario porque el contenedor no tiene comprobaciones de su salud
+  DB_OPTIONS: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5 
+
 jobs:
   dependency-review:
     name: Vulnerable dependencies 🔎
@@ -29,6 +37,17 @@ jobs:
   run:
     name: Run 🏃‍♂️
     runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: ${{ env.DB_IMAGE }}
+        env:
+          POSTGRES_DB: ${{ env.DB_NAME }}
+          POSTGRES_USER: ${{ env.DB_USERNAME }}
+          POSTGRES_PASSWORD: ${{ env.DB_PASSWORD }}
+        ports:
+          - 5432:5432
+        options: ${{ env.DB_OPTIONS }}
 
     steps:
       - name: Checkout ⬇️
@@ -61,6 +80,17 @@ jobs:
   test:
     name: Test backend 👨‍🔬
     runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: ${{ env.DB_IMAGE }}
+        env:
+          POSTGRES_DB: ${{ env.DB_NAME }}
+          POSTGRES_USER: ${{ env.DB_USERNAME }}
+          POSTGRES_PASSWORD: ${{ env.DB_PASSWORD }}
+        ports:
+          - 5432:5432
+        options: ${{ env.DB_OPTIONS }}
 
     steps:
       - name: Checkout ⬇️

--- a/.github/workflows/quality_checks.yml
+++ b/.github/workflows/quality_checks.yml
@@ -26,6 +26,60 @@ jobs:
           base-ref: ${{ github.event.pull_request.base.sha || 'master' }}
           head-ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
+  run:
+    name: Run 🏃‍♂️
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout ⬇️
+        uses: actions/checkout@v4.1.1
+        with:
+          show-progress: false
+
+      - name: Setup Python 🐍
+        uses: actions/setup-python@v5.0.0
+        with:
+          python-version: '3.x'
+          check-latest: true
+
+      - name: Install dependencies 📦
+        run: pip install -r requirements.txt
+
+      - name: Perform migrations 🗃️
+        run: python ./manage.py migrate
+
+      - name: Run Django Server 🏃‍♂️
+        run: |
+          python manage.py runserver &
+          sleep 10 # Espera a que el servidor esté listo
+
+      - name: Check server 🩺
+        run: |
+          curl -I http://127.0.0.1:8000/
+          sudo pkill python
+
+  test:
+    name: Test backend 👨‍🔬
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout ⬇️
+        uses: actions/checkout@v4.1.1
+        with:
+          show-progress: false
+
+      - name: Setup Python 🐍
+        uses: actions/setup-python@v5.0.0
+        with:
+          python-version: '3.x'
+          check-latest: true
+
+      - name: Install dependencies 📦
+        run: pip install -r requirements.txt
+
+      - name: Perform tests ⚒️
+        run: python ./manage.py test
+
   pr_context:
     name: Save PR context as artifact
     if: ${{ always() && !cancelled() && github.event_name == 'pull_request' }}
@@ -33,6 +87,8 @@ jobs:
     ## Add needed jobs here
     needs:
       - dependency-review
+      - test
+      - run
 
     steps:
       - name: Save PR context

--- a/.github/workflows/quality_checks.yml
+++ b/.github/workflows/quality_checks.yml
@@ -121,3 +121,18 @@ jobs:
 
       - name: Check if all commits comply with the specification
         uses: webiny/action-conventional-commits@v1.3.0
+
+  no_merge_commits:
+    name: No merge commits check 🚫
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout ⬇️
+        uses: actions/checkout@v4.1.1
+        with:
+          show-progress: false
+          fetch-depth: 0
+
+      - name: Check commits
+        uses: greenled/no-merge-commits-check@v1.0.1


### PR DESCRIPTION
Para los pull requests se ejecutan las versiones de main, pero para los eventos de push de una rama en concreto se ejecutan las de la rama en concreto, dando lugar a contradicciones.

Este PR hace backport de todos los cambios actuales de main haciendo cherry-pick de una forma que luego pueda ser rebasada correctamente